### PR TITLE
Add Numerai pipeline scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,35 @@ Learn how to create an ensemble trained on different targets.
 </a>
 
 A barebones example of how to build and upload your model to Numerai.
+## numerai-pipeline-A Usage
+
+### 執行流程
+1. 下載資料  
+   ```powershell
+   python - <<EOF
+   from src.data_fetch import download_latest_parquet
+   download_latest_parquet()
+   EOF
+   ```
+2. 訓練
+   ```powershell
+   python src/train.py
+   ```
+3. 檢視交叉驗證
+   ```powershell
+   python src/evaluate.py
+   ```
+4. 產生 live 預測（在 Compute Heavy / 本機均可）
+   ```powershell
+   python src/predict.py
+   ```
+
+> ✅ **說明**  
+> - `train.py` 會自動：
+>   1. 只讀近4年 era  
+>   2. Rank→Gaussian  
+>   3. PCA 取50 維  
+>   4. 5 × 5 = 25 模型（各自5 seed × 5 fold）訓練並存在 `models/`
+>   5. 對 OOF 預測做 **selective neutralize (proportion 0.85)**  
+> - `evaluate.py` 讀取 OOF CSV，列卷 era-wise 平均 corr 與波動。  
+> - `predict.py` 只需在 Compute Heavy 任務中下載最新 live parquet，跑一次即可輸出 `predictions.csv` 並上傳。

--- a/numerai-pipeline-A/src/config.py
+++ b/numerai-pipeline-A/src/config.py
@@ -1,0 +1,15 @@
+NUM_FEATURES          = 50          # PCA 主成分個數
+TRAIN_YEARS_BACK      = 4           # 只用最近 N 年資料
+SEEDS                 = [0,1,2,3,4]
+N_SPLITS              = 5           # era‐wise KFold
+LIGHTGBM_PARAMS = dict(
+    objective       = "regression",
+    n_estimators    = 400,
+    learning_rate   = 0.03,
+    max_depth       = 7,
+    num_leaves      = 64,
+    subsample       = 0.8,
+    colsample_bytree= 0.8,
+    reg_lambda      = 1.0,
+    min_child_samples = 20
+)

--- a/numerai-pipeline-A/src/data_fetch.py
+++ b/numerai-pipeline-A/src/data_fetch.py
@@ -1,0 +1,13 @@
+import numerapi, pyarrow.parquet as pq, os, pandas as pd
+from config import TRAIN_YEARS_BACK
+
+def download_latest_parquet(outfile="data/v5_full.parquet"):
+    napi = numerapi.NumerAPI()
+    file_id = napi.get_dataset_id("v5/train.parquet")
+    napi.download_dataset(file_id, outfile)
+
+
+def load_filtered_df(path="data/v5_full.parquet"):
+    df = pq.read_table(path).to_pandas(types_mapper={"float": "float16"})
+    recent_eras = sorted(df["era"].unique())[-52*TRAIN_YEARS_BACK:]
+    return df[df["era"].isin(recent_eras)].copy()

--- a/numerai-pipeline-A/src/evaluate.py
+++ b/numerai-pipeline-A/src/evaluate.py
@@ -1,0 +1,10 @@
+import pandas as pd, numpy as np
+
+def era_corr(df):
+    corrs = df.groupby("era").apply(lambda d: np.corrcoef(d["pred"], d["target"])[0,1])
+    return corrs.mean(), corrs.std()
+
+if __name__ == "__main__":
+    df = pd.read_csv("models/oof_with_pred.csv")
+    m, s = era_corr(df)
+    print(f"Era-wise corr mean={m:.4f}, std={s:.4f}")

--- a/numerai-pipeline-A/src/neutralize.py
+++ b/numerai-pipeline-A/src/neutralize.py
@@ -1,0 +1,16 @@
+import numpy as np, pandas as pd
+from scipy import stats
+
+def neutralize(df, columns, neutralizers, proportion=0.85, era_col="era"):
+    """Selective neutralize on given columns vs. neutralizer set."""
+    out = []
+    for era, era_df in df.groupby(era_col):
+        scores = era_df[columns].rank(method="first").values
+        scores = stats.norm.ppf((scores - 0.5) / scores.shape[0])
+        exposures = era_df[neutralizers].fillna(era_df[neutralizers].median()).values
+        scores = scores - proportion * exposures @ np.linalg.pinv(exposures, rcond=1e-6) @ scores
+        scores = scores / np.std(scores, axis=0, ddof=0)
+        out.append(scores)
+    clean = pd.DataFrame(np.vstack(out), columns=columns, index=df.index)
+    df[columns] = clean
+    return df

--- a/numerai-pipeline-A/src/predict.py
+++ b/numerai-pipeline-A/src/predict.py
@@ -1,0 +1,12 @@
+import glob, joblib, numpy as np, pandas as pd
+from preprocess import rank_gauss, pca_reduce
+
+def predict_live(live_df: pd.DataFrame):
+    feature_cols = [c for c in live_df.columns if c.startswith("feature_")]
+    feat = pca_reduce(rank_gauss(live_df[feature_cols]))
+    preds = np.zeros(len(live_df), dtype=np.float32)
+    for pkl in glob.glob("models/lgbm_seed*.pkl"):
+        model = joblib.load(pkl)
+        preds += model.predict(feat) / len(glob.glob("models/lgbm_seed*.pkl"))
+    live_df["prediction"] = preds
+    live_df.to_csv("predictions.csv", index=False)

--- a/numerai-pipeline-A/src/preprocess.py
+++ b/numerai-pipeline-A/src/preprocess.py
@@ -1,0 +1,18 @@
+import pandas as pd, numpy as np
+from sklearn.decomposition import PCA
+from scipy import stats
+from config import NUM_FEATURES
+
+def rank_gauss(df_feat: pd.DataFrame) -> pd.DataFrame:
+    """Rank → Gaussian transformation (per column)."""
+    gauss = []
+    for col in df_feat.columns:
+        r = df_feat[col].rank(method="first").values
+        r = (r - 0.5) / len(r)
+        gauss.append(stats.norm.ppf(r))
+    return pd.DataFrame(np.column_stack(gauss), columns=df_feat.columns, index=df_feat.index)
+
+
+def pca_reduce(feat_df: pd.DataFrame, n=NUM_FEATURES, seed=0):
+    pca = PCA(n_components=n, random_state=seed)
+    return pca.fit_transform(feat_df).astype(np.float32)

--- a/numerai-pipeline-A/src/train.py
+++ b/numerai-pipeline-A/src/train.py
@@ -1,0 +1,41 @@
+import os, joblib, gc, numpy as np, pandas as pd
+from sklearn.model_selection import GroupKFold
+import lightgbm as lgb
+from config import SEEDS, N_SPLITS, LIGHTGBM_PARAMS
+from data_fetch import load_filtered_df
+from preprocess import rank_gauss, pca_reduce
+from neutralize import neutralize
+
+
+def train():
+    df = load_filtered_df()
+    feature_cols = [c for c in df.columns if c.startswith("feature_")]
+    df_feat = rank_gauss(df[feature_cols])
+    pca_feat = pca_reduce(df_feat)
+    target = df["target"].astype(np.float32)
+    groups = df["era"].values
+
+    oof_preds = np.zeros(len(df), dtype=np.float32)
+    for seed in SEEDS:
+        lgb_params = LIGHTGBM_PARAMS | {"random_state": seed}
+        kf = GroupKFold(n_splits=N_SPLITS)
+        for fold, (tr_idx, val_idx) in enumerate(kf.split(pca_feat, target, groups)):
+            X_tr, y_tr = pca_feat[tr_idx], target.iloc[tr_idx]
+            X_val, y_val = pca_feat[val_idx], target.iloc[val_idx]
+            model = lgb.LGBMRegressor(**lgb_params)
+            model.fit(X_tr, y_tr, eval_set=[(X_val, y_val)],
+                      eval_metric="l1", callbacks=[lgb.early_stopping(50)])
+            joblib.dump(model, f"models/lgbm_seed{seed}_f{fold}.pkl")
+            oof_preds[val_idx] += model.predict(X_val) / len(SEEDS)
+        gc.collect()
+
+    df["pred"] = oof_preds
+    # selective neutralize: top 30 loading features
+    neutral_cols = feature_cols[:30]
+    df = neutralize(df, ["pred"], neutral_cols, proportion=0.85)
+    df[["era", "target", "pred"]].to_csv("models/oof_with_pred.csv", index=False)
+
+
+if __name__ == "__main__":
+    os.makedirs("models", exist_ok=True)
+    train()


### PR DESCRIPTION
## Summary
- implement config, data fetching, preprocessing, neutralization, training, evaluation and prediction scripts under `numerai-pipeline-A/src`
- document usage instructions for the new pipeline in `README.md`

## Testing
- `python -m py_compile numerai-pipeline-A/src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6850296cedd08322bbc29c347e8f3f74